### PR TITLE
make the 'no ratings' and '(0)' labels line up and not overlap each othe...

### DIFF
--- a/DAAppsViewController/DAAppViewCell.m
+++ b/DAAppsViewController/DAAppViewCell.m
@@ -114,7 +114,7 @@ static NSMutableDictionary *_iconCacheDictionary = nil;
             .origin.x = 88.0f,
             .origin.y = 54.0f,
             .size.width = 60.0f,
-            .size.height = 10.0f
+            .size.height = 12.0f
         };
         self.noRatingsLabel.font = [UIFont systemFontOfSize:10.0f];
         self.noRatingsLabel.textColor = [UIColor colorWithWhite:99.0f/255.0f alpha:1.0f];
@@ -125,8 +125,8 @@ static NSMutableDictionary *_iconCacheDictionary = nil;
         
         self.ratingsLabel = [[UILabel alloc] init];
         self.ratingsLabel.frame = (CGRect) {
-            .origin.x = 135.0f,
-            .origin.y = 51.5f,
+            .origin.x = 140.0f,
+            .origin.y = 54.0f,
             .size.width = 60.0f,
             .size.height = 12.0f
         };


### PR DESCRIPTION
attached a screen shot of what the cell text looked like without patch
![Screen Shot 2013-04-20 at 12 15 09 PM](https://f.cloud.github.com/assets/8692/404648/33005372-a960-11e2-91c9-12a00cee3b97.png)
