### PR TITLE
added default country code

### DIFF
--- a/DAAppsViewController/DAAppsViewController.m
+++ b/DAAppsViewController/DAAppsViewController.m
@@ -96,10 +96,6 @@
     dispatch_queue_t request_thread = dispatch_queue_create(NULL, NULL);
     dispatch_async(request_thread, ^{
         NSString *countryCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
-        if (!countryCode)
-        {
-            countryCode = @"US";
-        }
         NSMutableString *requestUrlString = [[NSMutableString alloc] init];
         [requestUrlString appendFormat:@"http://itunes.apple.com/%@/artist/", countryCode];
         [requestUrlString appendFormat:@"id%i", artistId];
@@ -180,14 +176,13 @@
     dispatch_async(request_thread, ^{
         NSString *appString = [appIds componentsJoinedByString:@","];
         NSString *countryCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
-        if (!countryCode)
-        {
-            countryCode = @"US";
-        }
         NSMutableString *requestUrlString = [[NSMutableString alloc] init];
         [requestUrlString appendFormat:@"http://itunes.apple.com/lookup"];
         [requestUrlString appendFormat:@"?id=%@", appString];
-        [requestUrlString appendFormat:@"&country=%@", countryCode];
+        if (countryCode)
+        {
+            [requestUrlString appendFormat:@"&country=%@", countryCode];
+        }
         NSURL *requestURL = [[NSURL alloc] initWithString:requestUrlString];
         
         NSError *requestError;
@@ -269,14 +264,13 @@
     dispatch_async(request_thread, ^{
         NSString *bundleString = [bundleIds componentsJoinedByString:@","];
         NSString *countryCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
-        if (!countryCode)
-        {
-            countryCode = @"US";
-        }
         NSMutableString *requestUrlString = [[NSMutableString alloc] init];
         [requestUrlString appendFormat:@"http://itunes.apple.com/lookup"];
         [requestUrlString appendFormat:@"?bundleId=%@", bundleString];
-        [requestUrlString appendFormat:@"&country=%@", countryCode];
+        if (countryCode)
+        {
+            [requestUrlString appendFormat:@"&country=%@", countryCode];
+        }
         NSURL *requestURL = [[NSURL alloc] initWithString:requestUrlString];
         
         NSError *requestError;
@@ -357,14 +351,13 @@
     dispatch_queue_t request_thread = dispatch_queue_create(NULL, NULL);
     dispatch_async(request_thread, ^{
         NSString *countryCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
-        if (!countryCode)
-        {
-            countryCode = @"US";
-        }
         NSMutableString *requestUrlString = [[NSMutableString alloc] init];
         [requestUrlString appendFormat:@"http://itunes.apple.com/search"];
         [requestUrlString appendFormat:@"?term=%@", searchTerm];
-        [requestUrlString appendFormat:@"&country=%@", countryCode];
+        if (countryCode)
+        {
+            [requestUrlString appendFormat:@"&country=%@", countryCode];
+        }
         [requestUrlString appendFormat:@"&entity=software"];
         NSURL *requestURL = [[NSURL alloc] initWithString:requestUrlString];
         


### PR DESCRIPTION
When testing, one of my devices was not displaying any results. The reason was due to `[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]` returning nil, and thus the country component of the URL was not formatted correctly.

I have added a check for nil, and if so set a default of `@"US"`. This has been done 4 times throughout `DAAppsViewController`.
