### PR TITLE
Adds support for affiliate and campaign tokens (under iOS 8)

### DIFF
--- a/DAAppsViewController/DAAppsViewController.h
+++ b/DAAppsViewController/DAAppsViewController.h
@@ -17,6 +17,11 @@
 // If it is nil, the title will be the artist/company name or 'Results'.
 @property (nonatomic, strong) NSString *pageTitle;
 
+#ifdef __IPHONE_8_0
+@property (nonatomic, strong) NSString *affiliateToken;
+@property (nonatomic, strong) NSString *campaignToken;
+#endif
+
 - (void)loadAppsWithArtistId:(NSInteger)artistId completionBlock:(void(^)(BOOL result, NSError *error))block;
 - (void)loadAllAppsWithArtistId:(NSInteger)artistId completionBlock:(void(^)(BOOL result, NSError *error))block;
 - (void)loadAppsWithAppIds:(NSArray *)appIds completionBlock:(void(^)(BOOL result, NSError *error))block;

--- a/DAAppsViewController/DAAppsViewController.m
+++ b/DAAppsViewController/DAAppsViewController.m
@@ -443,7 +443,19 @@
     
     if ([SKStoreProductViewController class]) {
         NSString *itunesItemIdentifier = [NSString stringWithFormat:@"%u", appObject.appId];
-        NSDictionary *appParameters = @{SKStoreProductParameterITunesItemIdentifier: itunesItemIdentifier};
+        NSMutableDictionary *appParameters = [@{SKStoreProductParameterITunesItemIdentifier: itunesItemIdentifier} mutableCopy];
+        
+#ifdef __IPHONE_8_0
+        if (&SKStoreProductParameterAffiliateToken) {
+            if (self.affiliateToken) {
+                [appParameters setObject:self.affiliateToken forKey:SKStoreProductParameterAffiliateToken];
+                if (self.campaignToken) {
+                    [appParameters setObject:self.campaignToken forKey:SKStoreProductParameterCampaignToken];
+                }
+            }
+        }
+#endif
+        
         SKStoreProductViewController *productViewController = [[SKStoreProductViewController alloc] init];
         [productViewController setDelegate:self];
         [productViewController loadProductWithParameters:appParameters completionBlock:nil];


### PR DESCRIPTION
iOS 8 added the ability to use affiliate codes. This pull request adds two properties to DAAppsViewController. `affiliateToken` and `campaignToken` setting a value for these will (under iOS 8) set `SKStoreProductParameterAffiliateToken` and `SKStoreProductParameterCampaignToken` on every `SKStoreProductViewController` shown by DAAppsViewController.

The pull request maintains support for iOS 7 in two ways:

1. the properties are only included if you target the iOS 8 sdk.
2. it checks for the existence of the iOS 8 only `SKStoreProductParameter` constants before referencing them. 

Let me know if you have any questions or suggestions for improvements to this pull request! :)