### PR TITLE
Bug fixing crash when compile with !use_frameworks in Podfile

### DIFF
--- a/DAAppsViewController.podspec
+++ b/DAAppsViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'DAAppsViewController'
-  s.version  = '1.4.1'
+  s.version  = '1.4.2'
   s.platform = :ios
   s.license  = 'MIT'
   s.summary  = 'DAAppsViewController is a simple way of displaying apps from the App Store in an aesthetically similar manner.'

--- a/DAAppsViewController.podspec
+++ b/DAAppsViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'DAAppsViewController'
-  s.version  = '1.4.0'
+  s.version  = '1.4.1'
   s.platform = :ios
   s.license  = 'MIT'
   s.summary  = 'DAAppsViewController is a simple way of displaying apps from the App Store in an aesthetically similar manner.'

--- a/DAAppsViewController/DAAppViewCell.m
+++ b/DAAppsViewController/DAAppViewCell.m
@@ -304,47 +304,49 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
                                                                  error:NULL];
             UIImage *iconImage = [UIImage imageWithData:iconData];
             if (iconImage) {
-                CGSize finalSize = _iconView.bounds.size;
-                UIGraphicsBeginImageContextWithOptions(finalSize, YES, 0.0f);
-                [iconImage drawInRect:(CGRect) {
-                    .size = finalSize
-                }];
-                
-                if (!DA_IS_IOS7) {
-                    [[UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAOverlayImage"] drawInRect:(CGRect) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    CGSize finalSize = _iconView.bounds.size;
+                    UIGraphicsBeginImageContextWithOptions(finalSize, YES, 0.0f);
+                    [iconImage drawInRect:(CGRect) {
                         .size = finalSize
                     }];
-                }
-                
-                UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
-                UIGraphicsEndImageContext();
-                
-                CGImageRef maskRef = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAMaskImage"].CGImage;
-                CGImageRef mask = CGImageMaskCreate(CGImageGetWidth(maskRef),
-                                                    CGImageGetHeight(maskRef),
-                                                    CGImageGetBitsPerComponent(maskRef),
-                                                    CGImageGetBitsPerPixel(maskRef),
-                                                    CGImageGetBytesPerRow(maskRef),
-                                                    CGImageGetDataProvider(maskRef), NULL, false);
-                CGImageRef maskedImageRef = CGImageCreateWithMask([resizedImage CGImage], mask);
-                UIImage *maskedImage = [UIImage imageWithCGImage:maskedImageRef];
-                CGImageRelease(mask);
-                CGImageRelease(maskedImageRef);
-                
-                if (maskedImage) {
-                    [_iconCache setObject:maskedImage forKey:iconURL];
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        if (self.appObject.iconURL == iconURL) {
-                            [UIView transitionWithView:self.iconView
-                                              duration:0.5f
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                self.iconView.image = maskedImage;
-                                            }
-                                            completion:nil];
-                        }
-                    });
-                }
+
+                    if (!DA_IS_IOS7) {
+                        [[UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAOverlayImage"] drawInRect:(CGRect) {
+                            .size = finalSize
+                        }];
+                    }
+
+                    UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
+                    UIGraphicsEndImageContext();
+
+                    CGImageRef maskRef = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAMaskImage"].CGImage;
+                    CGImageRef mask = CGImageMaskCreate(CGImageGetWidth(maskRef),
+                                                        CGImageGetHeight(maskRef),
+                                                        CGImageGetBitsPerComponent(maskRef),
+                                                        CGImageGetBitsPerPixel(maskRef),
+                                                        CGImageGetBytesPerRow(maskRef),
+                                                        CGImageGetDataProvider(maskRef), NULL, false);
+                    CGImageRef maskedImageRef = CGImageCreateWithMask([resizedImage CGImage], mask);
+                    UIImage *maskedImage = [UIImage imageWithCGImage:maskedImageRef];
+                    CGImageRelease(mask);
+                    CGImageRelease(maskedImageRef);
+
+                    if (maskedImage) {
+                        [_iconCache setObject:maskedImage forKey:iconURL];
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            if (self.appObject.iconURL == iconURL) {
+                                [UIView transitionWithView:self.iconView
+                                                  duration:0.5f
+                                                   options:UIViewAnimationOptionTransitionCrossDissolve
+                                                animations:^{
+                                                    self.iconView.image = maskedImage;
+                                                }
+                                                completion:nil];
+                            }
+                        });
+                    }
+                });
             }
         });
     }

--- a/DAAppsViewController/DAAppViewCell.m
+++ b/DAAppsViewController/DAAppViewCell.m
@@ -12,6 +12,25 @@ static NSCache *_iconCache = nil;
 static NSArray *_starRatingImages = nil;
 static NSNumberFormatter *_decimalNumberFormatter = nil;
 
+@interface UIImage (DAAppViewCell)
++ (UIImage *)imageNamedFromMainBundleOrFramework:(NSString *)name;
+@end
+
+@implementation UIImage (DAAppViewCell)
+
++ (UIImage *)imageNamedFromMainBundleOrFramework:(NSString *)name
+{
+    UIImage *image = [UIImage imageNamed:name];
+    if (!image) {
+        // Try to load from bundle
+        NSBundle *bundle = [NSBundle bundleForClass:[DAAppViewCell class]];
+        image = [UIImage imageNamed:name inBundle:bundle compatibleWithTraitCollection:nil];
+    }
+    
+    return image;
+}
+@end
+
 @interface DAAppViewCell ()
 
 @property (nonatomic, strong) UIImageView *iconView;
@@ -42,7 +61,12 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
         
         NSInteger numberOfStars = 11;
         NSMutableArray *starRatingImages = [[NSMutableArray alloc] initWithCapacity:numberOfStars];
-        UIImage *starsImageSheet = [UIImage imageNamed:@"DAAppsViewController.bundle/DAStarsImage"];
+        UIImage *starsImageSheet = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAStarsImage"];
+        if (!starsImageSheet) {
+            // Try to load from bundle
+            NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+            starsImageSheet = [UIImage imageNamed:@"DAAppsViewController.bundle/DAStarsImage" inBundle:bundle compatibleWithTraitCollection:nil];
+        }
         CGSize starRatingImageSize = (CGSize) {
             .width = starsImageSheet.size.width,
             .height = starsImageSheet.size.height / (CGFloat)numberOfStars
@@ -90,7 +114,7 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
             .size.height = 67.0f
         };
         cellImageShadowView.contentMode = UIViewContentModeScaleAspectFit;
-        cellImageShadowView.image = [UIImage imageNamed:@"DAAppsViewController.bundle/DAShadowImage"];
+        cellImageShadowView.image = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAShadowImage"];
         [self addSubview:cellImageShadowView];
         
         _iconView = [[UIImageView alloc] init];
@@ -179,8 +203,8 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
             [_purchaseButton setTitleShadowColor:[UIColor whiteColor] forState:UIControlStateNormal];
             [_purchaseButton.titleLabel setShadowOffset:CGSizeMake(0.0f, 1.0f)];
             
-            UIImage *buttonImage = [UIImage imageNamed:@"DAAppsViewController.bundle/DAButtonImage"];
-            UIImage *buttonImageSelected = [UIImage imageNamed:@"DAAppsViewController.bundle/DAButtonImageSelected"];
+            UIImage *buttonImage = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAButtonImage"];
+            UIImage *buttonImageSelected = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAButtonImageSelected"];
             [_purchaseButton setBackgroundImage:buttonImage forState:UIControlStateNormal];
             [_purchaseButton setBackgroundImage:buttonImageSelected forState:UIControlStateHighlighted];
         }
@@ -269,7 +293,7 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
     if (iconImage) {
         self.iconView.image = iconImage;
     } else {
-        self.iconView.image = [UIImage imageNamed:@"DAAppsViewController.bundle/DAPlaceholderImage"];
+        self.iconView.image = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAPlaceholderImage"];
         NSURL *iconURL = self.appObject.iconURL;
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             NSURLRequest *urlRequest = [NSURLRequest requestWithURL:iconURL
@@ -287,7 +311,7 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
                 }];
                 
                 if (!DA_IS_IOS7) {
-                    [[UIImage imageNamed:@"DAAppsViewController.bundle/DAOverlayImage"] drawInRect:(CGRect) {
+                    [[UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAOverlayImage"] drawInRect:(CGRect) {
                         .size = finalSize
                     }];
                 }
@@ -295,7 +319,7 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
                 UIImage *resizedImage = UIGraphicsGetImageFromCurrentImageContext();
                 UIGraphicsEndImageContext();
                 
-                CGImageRef maskRef = [UIImage imageNamed:@"DAAppsViewController.bundle/DAMaskImage"].CGImage;
+                CGImageRef maskRef = [UIImage imageNamedFromMainBundleOrFramework:@"DAAppsViewController.bundle/DAMaskImage"].CGImage;
                 CGImageRef mask = CGImageMaskCreate(CGImageGetWidth(maskRef),
                                                     CGImageGetHeight(maskRef),
                                                     CGImageGetBitsPerComponent(maskRef),

--- a/DAAppsViewController/DAAppsViewController.m
+++ b/DAAppsViewController/DAAppsViewController.m
@@ -94,10 +94,6 @@
     [requestUrlString appendString:@"https://itunes.apple.com/"];
     [requestUrlString appendString:path];
     [requestUrlString appendFormat:@"&entity=software"];
-    NSString *countryCode = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
-    if (countryCode) {
-        [requestUrlString appendFormat:@"&country=%@", countryCode];
-    }
     NSString *languagueCode = [[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode];
     if (languagueCode) {
         [requestUrlString appendFormat:@"&l=%@", languagueCode];

--- a/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
+++ b/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 			};
 			buildConfigurationList = 63948A9B170BCECD0065D68A /* Build configuration list for PBXProject "DAAppsViewControllerExample" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -252,7 +252,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -276,7 +276,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -289,7 +289,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DAAppsViewControllerExample/DAAppsViewControllerExample-Prefix.pch";
 				INFOPLIST_FILE = "DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielamitay.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -302,7 +302,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DAAppsViewControllerExample/DAAppsViewControllerExample-Prefix.pch";
 				INFOPLIST_FILE = "DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielamitay.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
+++ b/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		25DAA9672178E51C00303C09 /* DAAppsViewController.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = DAAppsViewController.podspec; path = ../DAAppsViewController.podspec; sourceTree = "<group>"; };
 		631EF346170E2AB500031F79 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		631EF34B170F6A6E00031F79 /* DAAppObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DAAppObject.h; sourceTree = "<group>"; };
 		631EF34C170F6A6E00031F79 /* DAAppObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DAAppObject.m; sourceTree = "<group>"; };
@@ -129,6 +130,7 @@
 				63948AD2170CE7B10065D68A /* DAAppViewCell.m */,
 				631EF34B170F6A6E00031F79 /* DAAppObject.h */,
 				631EF34C170F6A6E00031F79 /* DAAppObject.m */,
+				25DAA9672178E51C00303C09 /* DAAppsViewController.podspec */,
 				63FBB7CF171E99090047BD03 /* DAAppsViewController.bundle */,
 			);
 			name = DAAppsViewController;

--- a/DAAppsViewControllerExample/DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist
+++ b/DAAppsViewControllerExample/DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>DAAppsView</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
I just created an UIImage category inside the DAAppViewCell.m file to handle the load of images from Main Bundle (compiled as static library) or Framework (compiled as framework).

This could close the #25 issue, created by @stsandro.
