### PR TITLE
Raise the minimum target to 8.0

### DIFF
--- a/DAAppsViewController.podspec
+++ b/DAAppsViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'DAAppsViewController'
   s.version  = '1.4.0'
-  s.platform = :ios
+  s.platform = :ios, '8.0'
   s.license  = 'MIT'
   s.summary  = 'DAAppsViewController is a simple way of displaying apps from the App Store in an aesthetically similar manner.'
   s.homepage = 'https://github.com/danielamitay/DAAppsViewController'

--- a/DAAppsViewController/DAAppViewCell.m
+++ b/DAAppsViewController/DAAppViewCell.m
@@ -69,9 +69,7 @@ static NSNumberFormatter *_decimalNumberFormatter = nil;
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
         self.selectionStyle = UITableViewCellSelectionStyleGray;
-        if ([self respondsToSelector:@selector(setSeparatorInset:)]) {
-            self.separatorInset = UIEdgeInsetsZero;
-        }
+        self.separatorInset = UIEdgeInsetsZero;
         
         UIView *cellTopWhiteLine = [[UIView alloc] init];
         cellTopWhiteLine.frame = (CGRect) {

--- a/DAAppsViewController/DAAppsViewController.m
+++ b/DAAppsViewController/DAAppsViewController.m
@@ -271,16 +271,12 @@
         NSString *itunesItemIdentifier = [NSString stringWithFormat:@"%ld",  (long)appObject.appId];
         NSMutableDictionary *appParameters = [@{SKStoreProductParameterITunesItemIdentifier: itunesItemIdentifier} mutableCopy];
         
-#ifdef __IPHONE_8_0
-        if (&SKStoreProductParameterAffiliateToken) {
-            if (self.affiliateToken) {
-                [appParameters setObject:self.affiliateToken forKey:SKStoreProductParameterAffiliateToken];
-                if (self.campaignToken) {
-                    [appParameters setObject:self.campaignToken forKey:SKStoreProductParameterCampaignToken];
-                }
+        if (self.affiliateToken) {
+            [appParameters setObject:self.affiliateToken forKey:SKStoreProductParameterAffiliateToken];
+            if (self.campaignToken) {
+                [appParameters setObject:self.campaignToken forKey:SKStoreProductParameterCampaignToken];
             }
         }
-#endif
         
         SKStoreProductViewController *productViewController = [[SKStoreProductViewController alloc] init];
         [productViewController setDelegate:self];

--- a/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
+++ b/DAAppsViewControllerExample/DAAppsViewControllerExample.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DAAppsViewControllerExample/DAAppsViewControllerExample-Prefix.pch";
 				INFOPLIST_FILE = "DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielamitay.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -300,7 +300,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DAAppsViewControllerExample/DAAppsViewControllerExample-Prefix.pch";
 				INFOPLIST_FILE = "DAAppsViewControllerExample/DAAppsViewControllerExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielamitay.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ DAAppsViewController *appsViewController = [[DAAppsViewController alloc] init];
 
 ### Compatibility
 
-iOS5.0+
+iOS 8.0+
 
 ### Automatic Reference Counting (ARC) support
 


### PR DESCRIPTION
Will silence a bunch of compiler warnings. Xcode9 doesn't support
versions less than iOS 8.0. The platform version was absent in the
podspec.