### PR TITLE
Replace FREE with Get to match the App Store

### DIFF
--- a/DAAppsViewController/DAAppObject.m
+++ b/DAAppsViewController/DAAppObject.m
@@ -28,6 +28,9 @@
         _isUniversal = [features containsObject:@"iosUniversal"];
         _minimumOsVersion = [result objectForKey:@"minimumOsVersion"];
         _formattedPrice = [[result objectForKey:@"formattedPrice"] uppercaseString];
+        if ([_formattedPrice isEqualToString:@"FREE"]) {
+            _formattedPrice = @"Get";
+        }
         NSString *artworkUrl100 = [result objectForKey:@"artworkUrl100"];
         NSString *artworkUrl512 = [result objectForKey:@"artworkUrl512"];
         NSString *iconUrlString = (artworkUrl512.length ? artworkUrl512 : artworkUrl100);


### PR DESCRIPTION
Firstly, thanks for updating the repo to match the App Stores current design! As a long time user of `DAAppsViewController` this is great to see.

I updated one of my apps, and noticed it says "FREE" for free apps, but the App Store says "Get".

Looked into the code, seems the Free string comes from the API, so did a little match and replace.

If this is something you are OK with, merge away! If not, no drama.
